### PR TITLE
fix(url): Internet Explorer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ if(!window.System || !window.System.import){
   var modules = System._loader.modules, hasURL = false;
 
   try {
-    hasURL = typeof URLPolyfill != 'undefined' || new URL('test:///').protocol == 'test:';
+    hasURL = new URL('test:///').protocol == 'test:';
   }
   catch(e) {}
 


### PR DESCRIPTION
The hasUrl code copied from SystemJS is checking whether it needs to polyfill the URL object.  In the loader-default case, it's already been polyfilled, we only need to check whether to use the polyfill.