### PR TITLE
fix(DefaultLoader): use config API for map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,7 +219,7 @@ if (!PLATFORM.global.System || !PLATFORM.global.System.import) {
   };
 
   DefaultLoader.prototype.map = function(id, source) {
-    System.map[id] = source;
+    System.config({ map: { [id]: source } });
   };
 
   DefaultLoader.prototype.normalizeSync = function(moduleId, relativeTo) {


### PR DESCRIPTION
This change makes the loader compatible with SystemJS 0.20.0-rc.4.

I've verified this change is backwards compatible with SystemJS 0.17, 0.18 and 0.19.  I didn't check back any further than that.

https://gist.run/?id=d231e4c567d037e6766ca8ceaedbce50

Discussion with Guy in the SystemJS chat:
https://gitter.im/systemjs/systemjs?at=5878f3f7cbcb28177066014c