### PR TITLE
fix(index): use .keys instead of .entries close #43

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -177,9 +177,10 @@ if (!PLATFORM.global.System || !PLATFORM.global.System.import) {
 } else {
   PLATFORM.eachModule = function(callback) {
     if (System.registry) { // SystemJS >= 0.20.x
-      for (let [k, m] of System.registry.entries()) {
+      const keys = Array.from(System.registry.keys());
+      for (let i = 0; i < keys.length; i++) {
         try {
-          if (callback(k, m)) return;
+          if (callback(keys[i], System.registry.get(keys[i]))) { return; }
         } catch (e) {}
       }
       return;


### PR DESCRIPTION
`System.registry: Registry` - `Registry.prototype.entries` is only available if there is `Symbol` and `Symbol.iterator`.
- `aurelia-polyfills` does add `Symbol` and `Symbol.iterator`, but this is after `SystemJS` is loaded, so `Registry.prototype.entries` is not added.
- `aurelia-polyfills` does need a module loader so you can't load it before `SystemJS`.
