### PR TITLE
fix: improve compatibility with other AMD implementations.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ if (!PLATFORM.global.System || !PLATFORM.global.System.import) {
 
   DefaultLoader.prototype._import = function(moduleId) {
     return new Promise((resolve, reject) => {
-      requirejs([moduleId], resolve, reject);
+      PLATFORM.global.require([moduleId], resolve, reject);
     });
   };
 
@@ -144,7 +144,7 @@ if (!PLATFORM.global.System || !PLATFORM.global.System.import) {
     }
 
     return new Promise((resolve, reject) => {
-      requirejs([id], m => {
+      PLATFORM.global.require([id], m => {
         this.moduleRegistry[id] = m;
         resolve(ensureOriginOnExports(m, id));
       }, reject);


### PR DESCRIPTION
use PLATFORM.global.require instead of requirejs to continue supporting Dojo.

related to #48