### PR TITLE
fix: remove unnecessary inline SystemJS text plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -208,21 +208,6 @@ if (!PLATFORM.global.System || !PLATFORM.global.System.import) {
     }
   };
 
-  System.set('text', System.newModule({
-    'translate': function(load) {
-      return 'module.exports = "' + load.source
-        .replace(/(["\\])/g, '\\$1')
-        .replace(/[\f]/g, '\\f')
-        .replace(/[\b]/g, '\\b')
-        .replace(/[\n]/g, '\\n')
-        .replace(/[\t]/g, '\\t')
-        .replace(/[\r]/g, '\\r')
-        .replace(/[\u2028]/g, '\\u2028')
-        .replace(/[\u2029]/g, '\\u2029')
-      + '";';
-    }
-  }));
-
   DefaultLoader.prototype._import = function(moduleId) {
     return System.import(moduleId);
   };


### PR DESCRIPTION
Both cli+bundler+systemjs and skeleton-navigation (jspm skeletons) bundle npm package systemjs-plugin-text. The previous inline text plugin in loader-default is unnecessary, and it prevents aurelia-i18n-loader from working properly with SystemJS.

closes aurelia/i18n#289